### PR TITLE
Add / endpoint to keep heroku alive

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -2,6 +2,7 @@ import * as express from "express";
 import * as bodyParse from "body-parser";
 import * as mongoose from 'mongoose';
 import ExchangeRouter from './routers/exchangeRouter'
+import KeepAliveRouter from './routers/keepAliveRouter'
 import * as cors from "cors"
 
 const app = express();
@@ -22,6 +23,7 @@ app.set("port", process.env.PORT || 3000);
 
 // routers
 app.use('/api/v1/exchanges', cors(), ExchangeRouter)
+app.use('/', cors(), KeepAliveRouter)
 
 // apidoc
 app.use(express.static('public'));

--- a/src/routers/keepAliveRouter.ts
+++ b/src/routers/keepAliveRouter.ts
@@ -1,0 +1,22 @@
+import { Router, Request, Response } from 'express';
+const router: Router = Router();
+
+/**
+ * @api {get} / Request to keep it alive.
+ * @apiDescription Always return 200
+ *
+ * @apiSuccessExample {json} Success-Response:
+ *     HTTP/1.1 200 OK
+ * {
+ *    status: 'ok'
+ * }
+ */
+function alive(req: Request, res: Response) : void {
+  res
+    .status(200)
+    .json({status: 'ok'})
+}
+
+router.get('/', alive);
+
+export default router;


### PR DESCRIPTION
### What this PR do?
Resolve #6 

I created a new endpoint `/` to response with **200** and `{ status: 'ok' }`
Then I setted up an uptime robot ping every 28 minutes to that endpoint.

The new endpoint is already deployed.