### PR TITLE
Bancor URL fixed and SSL Certified ignored for Bancor API

### DIFF
--- a/src/services/fetchers/bancor.ts
+++ b/src/services/fetchers/bancor.ts
@@ -1,16 +1,18 @@
 import BankOptions from '../bankInterfaces';
 import axios from 'axios';
+import https = require('https');
 
 class Bancor {
   readonly url: string;
+  readonly agent: object;
 
   constructor () {
-    process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
     this.url = 'https://bit.ly/35ENSfE';
+    this.agent = new https.Agent({ rejectUnauthorized: false });
   }
 
   run () : Promise<BankOptions> {
-    return axios.get(this.url)
+    return axios.get(this.url, { httpsAgent: this.agent })
     .then(response => {
       const result = response.data;
       let buy, sell;

--- a/src/services/fetchers/bancor.ts
+++ b/src/services/fetchers/bancor.ts
@@ -5,7 +5,8 @@ class Bancor {
   readonly url: string;
 
   constructor () {
-    this.url = "http://bit.ly/2MbulMK";
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+    this.url = 'https://bit.ly/35ENSfE';
   }
 
   run () : Promise<BankOptions> {


### PR DESCRIPTION
### The purpose of this PR is to get working Bancor prices at [eldolar](https://eldolar.github.io/web/) again.

![image](https://user-images.githubusercontent.com/4787484/97371116-575c7880-188f-11eb-8e1c-f846856d3aba.png)

Disclaimer:
- To fix this bug a dirty hack was added
```
this.agent = new https.Agent({ rejectUnauthorized: false });
...
return axios.get(this.url, { httpsAgent: this.agent })
```
It works but will make all your requests to Bancor API insecure, but given this is a scrapping application I didn't see any problem to use this.